### PR TITLE
feat: add file and folder renaming functionality in GitHub file tree

### DIFF
--- a/modules/collaboration/components/GitHubCollabPlayground.tsx
+++ b/modules/collaboration/components/GitHubCollabPlayground.tsx
@@ -1,21 +1,69 @@
 "use client";
-import { useEffect, useState,useCallback } from "react";
-import { Users, Clock, AlertCircle, Wifi, WifiOff, GitBranch,Loader2,FileText,X } from "lucide-react";
+//github collab playground - the one with direct commits ,no local state ,no source control, just a simple editor with file tree and commit button, all changes are directly commited to github and reflected to all users in real time, read only for now, no conflict handling, just a simple collab editor on top of github repo
+import { useEffect, useState, useCallback, useRef } from "react";
+import {
+  Users,
+  Clock,
+  AlertCircle,
+  Wifi,
+  WifiOff,
+  GitBranch,
+  Loader2,
+  FileText,
+  X,
+  ArrowLeft,
+  RefreshCw,
+  GitCommit,
+  Play,
+  Square,
+} from "lucide-react";
 import { toast } from "sonner";
 import { joinCollabSession } from "@/modules/collaboration/actions";
 import { useCollabSocket } from "@/modules/collaboration/hooks/useCollabSocket";
+import { useCollabParticipants } from "@/modules/collaboration/hooks/useCollabParticipants";
 import type { CollabSessionData } from "@/modules/collaboration/types";
 import { LoadingStep } from "@/modules/playground/components/loader";
 import { currentUser } from "@/modules/auth/actions";
-import React from "react";
-import { useCollabParticipants } from "@/modules/collaboration/hooks/useCollabParticipants";
 import { ParticipantsPanel } from "./ParticipantsPanel";
 import { GitHubFileTree } from "@/modules/github/components/github-file-tree";
 import { fetchRepositoryTree, fetchFileContent } from "@/modules/github/actions";
 import { CollabEditor } from "./CollabEditor";
 import { getEditorLanguage } from "@/modules/playground/lib/editor-config";
+import { Button } from "@/components/ui/button";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import TerminalComponent, { TerminalRef } from "@/modules/webContainers/components/terminal";
+import { WebContainerPreview } from "@/modules/webContainers/components/WebContainerPreview";
 
+// Workspace layer — same as single-user playground
+import {
+  useGitWorkspace,
+  useActiveFile,
+  useChangeCount,
+} from "@/modules/github/hooks/Usegitworkspace";
+import { useWebContainerForGithub } from "@/modules/webContainers/hooks/useWebContainerForGithub";
+import { NewFileDialog } from "@/modules/github/components/dialogs/new-file-dialog";
+import { NewFolderDialog } from "@/modules/github/components/dialogs/new-folder-dialog";
+import { SourceControlPanel } from "@/modules/github/components/SourceControlPanel";
+import { DiffViewer } from "@/modules/github/components/diff-viewer";
+import { commitAllChangesToGitHub } from "@/modules/github/actions";
+import PlaygroundEditor from "@/modules/playground/components/playgroundEditor";
 
+// Phase 1 collab bridge
+import { useCollabWorkspace } from "@/modules/collaboration/hooks/useCollabWorkspace";
 interface GitHubFile {
   name: string;
   path: string;
@@ -25,26 +73,50 @@ interface GitHubFile {
   content?: string;
 }
 
-interface OpenFile {
-  path: string;
-  content: string;
-  sha: string;
-  name: string;
-}
 
 interface GitHubCollabPlaygroundProps {
   session: CollabSessionData;
 }
 
 export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps) {
+ 
+  const [user, setUser] = useState<{
+    id: string;
+    name: string;
+    image?: string;
+  } | null>(null);
     const [isJoining, setIsJoining] = useState(true);
-    const [joinError, setJoinError] = useState<string | null>(null);
-    const [user,setUser] = useState<{id:string;name:string;image?:string} | null>(null);
-    const [files, setFiles] = useState<GitHubFile[]>([]);
+  const [joinError, setJoinError] = useState<string | null>(null);
+
+  // Derived: is this user the session host?
+  const isHost = !!user && user.id === session.hostId;
+
+  // ── UI state ────────────────────────────────────────────────────────────
+  const [showSourceControl, setShowSourceControl] = useState(false);
+  const [newFileDialogOpen, setNewFileDialogOpen] = useState(false);
+  const [newFolderDialogOpen, setNewFolderDialogOpen] = useState(false);
+  const [currentContextPath, setCurrentContextPath] = useState("");
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [fileToDelete, setFileToDelete] = useState<GitHubFile | null>(null);
+  const [deleteFolderDialogOpen, setDeleteFolderDialogOpen] = useState(false);
+  const [folderToDelete, setFolderToDelete] = useState<{
+    path: string;
+    name: string;
+  } | null>(null);
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(
+    new Set([""])
+  );
+  const [showDiff, setShowDiff] = useState(false);
+  const [diffFilePath, setDiffFilePath] = useState<string | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [isLoadingTree, setIsLoadingTree] = useState(false);
-  const [openFile, setOpenFile] = useState<OpenFile | null>(null);
-  const [isLoadingFile, setIsLoadingFile] = useState(false);
-  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set([""]));
+
+  const terminalRef = useRef<TerminalRef>(null);
+  const [isTerminalReady, setIsTerminalReady] = useState(false);
+  const autoStartAttempted = useRef(false);
+  const manuallyCreatedFilesRef = useRef<Set<string>>(new Set());
+
     const {socket,isConnected, emitFileOpen } = useCollabSocket(
         session.sessionId,
         user?.id,
@@ -56,6 +128,61 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
         currentUserId:user?.id,
 
     });
+    const {
+    files,
+    initializeWorkspace,
+    openFile: openFileInWorkspace,
+    closeFile,
+    updateFileContent,
+    getAllChanges,
+    modifiedFiles,
+    createdFiles,
+    deletedFiles,
+    addFileToTree,
+    removeFileFromTree,
+    updateFileInTree,
+    markFileCreated,
+    markFileDeleted,
+    unmarkFileCreated,
+    unstageAllFiles,
+  } = useGitWorkspace();
+
+  const activeFile  = useActiveFile();
+  const changeCount = useChangeCount();
+  const openFiles   = useGitWorkspace((s) => s.openFiles);
+  const remoteState = useGitWorkspace((s) => s.remoteState);
+
+  const {
+    broadcastContentChange,
+    broadcastFileCreate,
+    broadcastFileDelete,
+    broadcastFileRename,
+  } = useCollabWorkspace({
+    socket,
+    sessionId: session.sessionId,
+    currentUserId: user?.id,
+  });
+
+  const {
+    serverUrl,
+    isLoading: isWebContainerLoading,
+    error: webContainerError,
+    instance: webContainerInstance,
+    isServerRunning,
+    isSupported: isWebContainerSupported,
+    projectType,
+    startServer,
+    restartServer,
+    stopServer,
+    isReady,
+  } = useWebContainerForGithub({
+    files,
+    repoFullName: `${session.repoOwner}/${session.repoName}`,
+    currentBranch: session.branch,
+    terminalRef,
+    autoStart: false,
+  });
+
 
     const loadRepositoryTree = useCallback(async () => {
     if (!session.repoOwner || !session.repoName || !session.branch) {
@@ -74,11 +201,29 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
       );
 
       if (result.success) {
-        console.log(`✅ Loaded ${result.data.length} files from GitHub`);
-        setFiles(result.data);
-        
-        // Expand root directory by default
-        setExpandedDirs(new Set([""]));
+       const filesWithContent = await Promise.all(
+          result.data.map(async (file: GitHubFile) => {
+            if (file.type === "file") {
+              const contentResult = await fetchFileContent(
+                session.repoOwner!,
+                session.repoName!,
+                file.path,
+                session.branch
+              );
+              if (contentResult.success) {
+                return { ...file, content: contentResult.data };
+              }
+            }
+            return file;
+          })
+        );
+
+        initializeWorkspace(
+          `${session.repoOwner}/${session.repoName}`,
+          session.branch,
+          filesWithContent
+        );
+
       } else {
         toast.error(result.error || "Failed to load repository");
         console.error("❌ Tree fetch error:", result.error);
@@ -89,53 +234,9 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
     } finally {
       setIsLoadingTree(false);
     }
-  }, [session.repoOwner, session.repoName, session.branch]);
+  }, [session.repoOwner, session.repoName, session.branch,initializeWorkspace]);
 
-   const handleFileSelect = useCallback(async (file: GitHubFile) => {
-    if (file.type === "dir") return;
-
-    if (!session.repoOwner || !session.repoName || !session.branch) {
-      toast.error("Repository information missing");
-      return;
-    }
-
-    setIsLoadingFile(true);
-    try {
-      console.log(`📄 Fetching content for ${file.path}`);
-      
-      const result = await fetchFileContent(
-        session.repoOwner,
-        session.repoName,
-        file.path,
-        session.branch
-      );
-
-      if (result.success) {
-        console.log(`✅ Loaded file: ${file.name}`);
-        
-        setOpenFile({
-          path: file.path,
-          content: result.data,
-          sha: file.sha,
-          name: file.name,
-        });
-
-        // 🔥 Emit file open event to other users
-        emitFileOpen(file.sha, file.path);
-        updateActivity(file.path);
-
-        toast.success(`Opened ${file.name}`);
-      } else {
-        toast.error(result.error || "Failed to load file");
-        console.error("❌ File fetch error:", result.error);
-      }
-    } catch (error) {
-      console.error("❌ Error loading file:", error);
-      toast.error("Failed to load file content");
-    } finally {
-      setIsLoadingFile(false);
-    }
-  }, [session.repoOwner, session.repoName, session.branch, emitFileOpen, updateActivity]);
+  
 
 
 
@@ -183,28 +284,400 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
     },[session.sessionId,loadRepositoryTree]);
 
     useEffect(() => {
-    if (!socket) return;
+    const handleTerminalReady = () => setIsTerminalReady(true);
+    window.addEventListener("terminalReady", handleTerminalReady);
+    return () => window.removeEventListener("terminalReady", handleTerminalReady);
+  }, []);
+  useEffect(() => {
+    if (
+      !isWebContainerSupported ||
+      !isReady ||
+      !isTerminalReady ||
+      autoStartAttempted.current ||
+      isServerRunning
+    )
+      return;
 
-    const handleRemoteFileOpen = (payload: {
-      userId: string;
-      userName: string;
-      fileId: string;
-      filePath: string;
-    }) => {
-      if (payload.userId === user?.id) return;
-      
-      console.log(`👤 ${payload.userName} opened: ${payload.filePath}`);
-      // Could show a toast or indicator here
-    };
+    autoStartAttempted.current = true;
+    const timer = setTimeout(async () => {
+      try {
+        await startServer();
+        setShowPreview(true);
+      } catch {
+        autoStartAttempted.current = false;
+      }
+    }, 1500);
 
-    socket.on("user:file-changed", handleRemoteFileOpen);
+    return () => clearTimeout(timer);
+  }, [isReady, isTerminalReady, isServerRunning, isWebContainerSupported, startServer]);
+  const handleFileSelect = useCallback(
+    async (file: GitHubFile) => {
+      if (file.type === "dir") return;
 
-    return () => {
-      socket.off("user:file-changed", handleRemoteFileOpen);
-    };
-  }, [socket, user?.id]);
+      openFileInWorkspace(file);
+      emitFileOpen(file.sha || file.path, file.path);
+      updateActivity(file.path);
 
-    if (isJoining) {
+      // Mirror into WebContainer
+      if (webContainerInstance && isReady) {
+        const content = file.content || "";
+        await webContainerInstance.fs.writeFile(`/${file.path}`, content, "utf-8");
+      }
+    },
+    [openFileInWorkspace, emitFileOpen, updateActivity, webContainerInstance, isReady]
+  );
+  const handleContentChange = useCallback(
+    (newContent: string) => {
+      if (!activeFile) return;
+
+      updateFileContent(activeFile.path, newContent);
+
+      // Broadcast to peers (Phase 1 — full content, no deltas)
+      broadcastContentChange(activeFile.path, activeFile.sha, newContent);
+
+      // Mirror into own WebContainer
+      if (isWebContainerSupported && webContainerInstance) {
+        webContainerInstance.fs
+          .writeFile(`/${activeFile.path}`, newContent, "utf-8")
+          .catch(console.error);
+      }
+    },
+    [
+      activeFile,
+      updateFileContent,
+      broadcastContentChange,
+      isWebContainerSupported,
+      webContainerInstance,
+    ]
+  );
+  const handleCreateFile = useCallback(
+    async (path: string, filename: string) => {
+      const fullPath = path ? `${path}/${filename}` : filename;
+
+      if (files.some((f) => f.path === fullPath)) {
+        toast.error(`File "${filename}" already exists`);
+        return;
+      }
+
+      const newFile: GitHubFile = {
+        name: filename,
+        path: fullPath,
+        sha: "",
+        size: 0,
+        type: "file",
+        content: "",
+      };
+
+      addFileToTree(newFile);
+      markFileCreated(fullPath);
+
+      if (path) setExpandedDirs((prev) => new Set([...prev, path]));
+      openFileInWorkspace(newFile);
+
+      if (webContainerInstance && isReady) {
+        await webContainerInstance.fs.writeFile(`/${fullPath}`, "", "utf-8");
+      }
+
+      // Broadcast to peers
+      broadcastFileCreate(fullPath, "");
+
+      toast.success(`Created ${filename}`, {
+        description: "Stage and commit when ready",
+      });
+    },
+    [
+      files,
+      addFileToTree,
+      markFileCreated,
+      openFileInWorkspace,
+      webContainerInstance,
+      isReady,
+      broadcastFileCreate,
+    ]
+  );
+  const handleCreateFolder = useCallback(
+    async (path: string, folderName: string) => {
+      const fullPath = path ? `${path}/${folderName}` : folderName;
+      const gitkeepPath = `${fullPath}/.gitkeep`;
+
+      if (files.some((f) => f.path === gitkeepPath)) {
+        toast.error(`Folder "${folderName}" already exists`);
+        return;
+      }
+
+      const placeholder: GitHubFile = {
+        name: ".gitkeep",
+        path: gitkeepPath,
+        sha: "",
+        size: 0,
+        type: "file",
+        content: "",
+      };
+
+      addFileToTree(placeholder);
+      markFileCreated(gitkeepPath);
+      setExpandedDirs((prev) =>
+        new Set([...prev, ...(path ? [path] : []), fullPath])
+      );
+
+      if (webContainerInstance && isReady) {
+        await webContainerInstance.fs.mkdir(`/${fullPath}`, { recursive: true });
+        await webContainerInstance.fs.writeFile(`/${gitkeepPath}`, "", "utf-8");
+      }
+
+      // Broadcast the .gitkeep creation so peers see the folder too
+      broadcastFileCreate(gitkeepPath, "");
+
+      toast.success(`Created ${folderName}/`, {
+        description: "Stage and commit when ready",
+      });
+    },
+    [
+      files,
+      addFileToTree,
+      markFileCreated,
+      webContainerInstance,
+      isReady,
+      broadcastFileCreate,
+    ]
+  );
+  const handleDeleteFile = useCallback(async () => {
+    if (!fileToDelete) return;
+
+    const isLocalOnly = !fileToDelete.sha;
+
+    if (activeFile?.path === fileToDelete.path) closeFile(fileToDelete.path);
+
+    if (isLocalOnly) {
+      removeFileFromTree(fileToDelete.path);
+      unmarkFileCreated(fileToDelete.path);
+    } else {
+      removeFileFromTree(fileToDelete.path);
+      markFileDeleted(fileToDelete.path);
+    }
+
+    if (webContainerInstance && isReady) {
+      try {
+        await webContainerInstance.fs.rm(`/${fileToDelete.path}`);
+      } catch {}
+    }
+
+    // Broadcast deletion
+    broadcastFileDelete(fileToDelete.path);
+
+    setDeleteDialogOpen(false);
+    setFileToDelete(null);
+    toast.success(`Deleted ${fileToDelete.name}`);
+  }, [
+    fileToDelete,
+    activeFile,
+    closeFile,
+    removeFileFromTree,
+    unmarkFileCreated,
+    markFileDeleted,
+    webContainerInstance,
+    isReady,
+    broadcastFileDelete,
+  ]);
+  const handleDeleteFolder = useCallback(async () => {
+    if (!folderToDelete) return;
+
+    const folderFiles = files.filter(
+      (f) =>
+        f.path.startsWith(folderToDelete.path + "/") ||
+        f.path === folderToDelete.path
+    );
+
+    if (activeFile?.path.startsWith(folderToDelete.path + "/")) {
+      closeFile(activeFile.path);
+    }
+
+    setExpandedDirs((prev) => {
+      const next = new Set(prev);
+      next.delete(folderToDelete.path);
+      Array.from(next).forEach((p) => {
+        if (p.startsWith(folderToDelete.path + "/")) next.delete(p);
+      });
+      return next;
+    });
+
+    folderFiles.forEach((file) => {
+      removeFileFromTree(file.path);
+      if (!file.sha) {
+        unmarkFileCreated(file.path);
+      } else {
+        markFileDeleted(file.path);
+      }
+      // Broadcast each file deletion
+      broadcastFileDelete(file.path);
+    });
+
+    if (webContainerInstance && isReady) {
+      try {
+        await webContainerInstance.fs.rm(`/${folderToDelete.path}`, {
+          recursive: true,
+        });
+      } catch {}
+    }
+
+    setDeleteFolderDialogOpen(false);
+    setFolderToDelete(null);
+    toast.success(`Deleted ${folderToDelete.name}/`);
+  }, [
+    folderToDelete,
+    files,
+    activeFile,
+    closeFile,
+    removeFileFromTree,
+    unmarkFileCreated,
+    markFileDeleted,
+    webContainerInstance,
+    isReady,
+    broadcastFileDelete,
+  ]);
+
+  const handleRenameFile = useCallback(
+    async (file: GitHubFile, newName: string) => {
+      const dir = file.path.includes("/")
+        ? file.path.substring(0, file.path.lastIndexOf("/"))
+        : "";
+      const newPath = dir ? `${dir}/${newName}` : newName;
+
+      if (files.some((f) => f.path === newPath)) {
+        toast.error(`"${newName}" already exists`);
+        return;
+      }
+
+      // --- Old path: delete side ---
+      if (activeFile?.path === file.path) closeFile(file.path);
+      removeFileFromTree(file.path);
+      if (!file.sha) {
+        unmarkFileCreated(file.path);
+      } else {
+        markFileDeleted(file.path);
+      }
+
+      // --- New path: add side ---
+      const currentContent =
+        openFiles.find((f) => f.path === file.path)?.content ??
+        file.content ??
+        "";
+
+      const newFile: GitHubFile = {
+        name: newName,
+        path: newPath,
+        sha: "",
+        size: currentContent.length,
+        type: "file",
+        content: currentContent,
+      };
+
+      addFileToTree(newFile);
+      markFileCreated(newPath);
+      openFileInWorkspace(newFile);
+
+      // WebContainer
+      if (webContainerInstance && isReady) {
+        try {
+          const dirPart = newPath.split("/").slice(0, -1).join("/");
+          if (dirPart)
+            await webContainerInstance.fs.mkdir(`/${dirPart}`, {
+              recursive: true,
+            });
+          await webContainerInstance.fs.writeFile(
+            `/${newPath}`,
+            currentContent,
+            "utf-8"
+          );
+          await webContainerInstance.fs.rm(`/${file.path}`);
+        } catch (e) {
+          console.warn("WC rename sync failed:", e);
+        }
+      }
+
+      // Broadcast rename
+      broadcastFileRename(file.path, newPath, currentContent);
+
+      toast.success(`Renamed to ${newName}`, {
+        description: "Staged as D + A. Commit via Source Control.",
+      });
+    },
+    [
+      files,
+      activeFile,
+      openFiles,
+      closeFile,
+      removeFileFromTree,
+      unmarkFileCreated,
+      markFileDeleted,
+      addFileToTree,
+      markFileCreated,
+      openFileInWorkspace,
+      webContainerInstance,
+      isReady,
+      broadcastFileRename,
+    ]
+  );
+  const handleCommit = useCallback(
+    async (message: string, description?: string) => {
+      if (!message.trim()) {
+        toast.error("Please enter a commit message");
+        return;
+      }
+      if (!isHost) {
+        toast.error("Only the host can commit changes");
+        return;
+      }
+
+      setIsSaving(true);
+      try {
+        const changes = getAllChanges();
+        if (changes.length === 0) {
+          toast.error("No changes to commit");
+          return;
+        }
+
+        const fullMessage = description?.trim()
+          ? `${message}\n\n${description}`
+          : message;
+
+        const result = await commitAllChangesToGitHub(
+          session.repoOwner!,
+          session.repoName!,
+          changes,
+          fullMessage,
+          session.branch
+        );
+
+        if (result.success) {
+          toast.success(`Committed ${changes.length} file(s)`);
+          initializeWorkspace(
+            `${session.repoOwner}/${session.repoName}`,
+            session.branch,
+            result.updatedFiles
+          );
+          await loadRepositoryTree();
+        } else {
+          toast.error(result.error || "Failed to commit changes");
+        }
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [
+      isHost,
+      getAllChanges,
+      initializeWorkspace,
+      loadRepositoryTree,
+      session.repoOwner,
+      session.repoName,
+      session.branch,
+    ]
+  );
+
+    
+
+   if (isJoining) {
     return (
       <div className="flex flex-col items-center justify-center h-screen p-4">
         <div className="w-full max-w-md p-6 rounded-lg shadow-sm border">
@@ -232,56 +705,214 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
   }
 
   const expiresAt = new Date(session.expiresAt);
-  const now = new Date();
   const hoursRemaining = Math.max(
     0,
-    Math.floor((expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60))
+    Math.floor((expiresAt.getTime() - Date.now()) / (1000 * 60 * 60))
   );
 
-  return (
-    <div className="flex h-screen w-full bg-background">
-      {/* 🔥 NEW: File Tree Sidebar */}
-      <div className="w-64 border-r bg-muted/30 overflow-auto flex flex-col">
-        <div className="p-4 border-b space-y-3">
-          <div>
-            <h2 className="font-semibold">{session.repoName}</h2>
-            <p className="text-xs text-muted-foreground">{session.repoOwner}</p>
-          </div>
-          
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <GitBranch className="h-3 w-3" />
-            <span>{session.branch}</span>
-          </div>
+  // ── Sidebar tabs: hosts see Explorer + Source Control; guests only Explorer
+  const sidebarTabs = isHost ? ["Explorer", "Source Control"] : ["Explorer"];
 
-          <div className="text-xs text-muted-foreground pt-2 border-t">
-            Read-only mode • {files.length} files
-          </div>
-        </div>
-        
-        <div className="flex-1 overflow-auto">
-          {isLoadingTree ? (
-            <div className="flex items-center justify-center p-8">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
-          ) : files.length > 0 ? (
-            <GitHubFileTree
-              files={files}
-              onFileSelect={handleFileSelect}
-              selectedPath={openFile?.path}
-              expandedDirs={expandedDirs}
-              onExpandedDirsChange={setExpandedDirs}
-            />
-          ) : (
-            <div className="flex flex-col items-center justify-center p-8 text-center text-sm text-muted-foreground">
-              <p>No files found in repository</p>
-            </div>
+  // ─────────────────────────────────────────────────────────────────────────
+  return (
+    <div className="flex h-screen">
+      {/* ── Sidebar ──────────────────────────────────────────────────────── */}
+      <div className="w-64 border-r bg-muted/30 overflow-auto flex flex-col">
+        {/* Tab bar — host sees both tabs, guest sees only Explorer */}
+        <div className="flex border-b">
+          <button
+            className={`flex-1 py-2 text-sm ${
+              !showSourceControl
+                ? "bg-background border-b-2 border-primary"
+                : "text-muted-foreground"
+            }`}
+            onClick={() => setShowSourceControl(false)}
+          >
+            Explorer
+          </button>
+
+          {isHost && (
+            <button
+              className={`flex-1 py-2 text-sm ${
+                showSourceControl
+                  ? "bg-background border-b-2 border-primary"
+                  : "text-muted-foreground"
+              }`}
+              onClick={() => setShowSourceControl(true)}
+            >
+              Source Control
+              {changeCount > 0 && (
+                <span className="ml-2 px-1.5 py-0.5 text-xs rounded-full bg-blue-500 text-white">
+                  {changeCount}
+                </span>
+              )}
+            </button>
           )}
         </div>
+
+        {/* Explorer panel */}
+        {!showSourceControl ? (
+          <>
+            <div className="p-4 border-b space-y-3">
+              <div>
+                <h2 className="font-semibold">{session.repoName}</h2>
+                <p className="text-xs text-muted-foreground">
+                  {session.repoOwner}
+                </p>
+              </div>
+
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <GitBranch className="h-3 w-3" />
+                <span>{session.branch}</span>
+                {!isHost && (
+                  <span className="ml-1 px-1.5 py-0.5 bg-muted rounded text-xs">
+                    read-only branch
+                  </span>
+                )}
+              </div>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={loadRepositoryTree}
+                disabled={isLoadingTree}
+                className="h-6 w-6"
+              >
+                <RefreshCw
+                  className={`h-3 w-3 ${isLoadingTree ? "animate-spin" : ""}`}
+                />
+              </Button>
+
+              {/* WebContainer status */}
+              {isWebContainerSupported && (
+                <div className="pt-2 border-t space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <div
+                        className={`w-2 h-2 rounded-full ${
+                          isServerRunning ? "bg-green-500" : "bg-gray-400"
+                        }`}
+                      />
+                      <span className="text-xs font-medium">
+                        {isServerRunning
+                          ? `${projectType} (Running)`
+                          : projectType || "Web Project"}
+                      </span>
+                    </div>
+                  </div>
+
+                  {isServerRunning && (
+                    <>
+                      <div className="flex gap-1">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={stopServer}
+                          className="flex-1"
+                        >
+                          <Square className="h-3 w-3 mr-1" />
+                          Stop
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={restartServer}
+                          className="flex-1"
+                        >
+                          <RefreshCw className="h-3 w-3 mr-1" />
+                          Restart
+                        </Button>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setShowPreview(!showPreview)}
+                        className="w-full"
+                      >
+                        {showPreview ? "Hide" : "Show"} Preview
+                      </Button>
+                    </>
+                  )}
+
+                  {!isServerRunning && isWebContainerLoading && (
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      <span>Starting server...</span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Guest role badge */}
+              {!isHost && (
+                <div className="pt-2 border-t">
+                  <p className="text-xs text-muted-foreground">
+                    You are a{" "}
+                    <span className="font-medium text-foreground">guest</span>.
+                    Edits sync to all participants.
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {/* File tree */}
+            <div className="flex-1 overflow-auto">
+              {isLoadingTree ? (
+                <div className="flex items-center justify-center p-8">
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                </div>
+              ) : (
+                <GitHubFileTree
+                  files={files}
+                  onFileSelect={handleFileSelect}
+                  selectedPath={activeFile?.path}
+                  onCreateFile={(path) => {
+                    setCurrentContextPath(path);
+                    setNewFileDialogOpen(true);
+                  }}
+                  onCreateFolder={(path) => {
+                    setCurrentContextPath(path);
+                    setNewFolderDialogOpen(true);
+                  }}
+                  onDeleteFile={(file) => {
+                    setFileToDelete(file);
+                    setDeleteDialogOpen(true);
+                  }}
+                  onDeleteFolder={(path, name) => {
+                    setFolderToDelete({ path, name });
+                    setDeleteFolderDialogOpen(true);
+                  }}
+                  expandedDirs={expandedDirs}
+                  onExpandedDirsChange={setExpandedDirs}
+                  modifiedFiles={modifiedFiles}
+                  createdFiles={createdFiles}
+                  deletedFiles={deletedFiles}
+                  onRenameFile={handleRenameFile}
+                />
+              )}
+            </div>
+          </>
+        ) : (
+          // Source Control — host only (tab is hidden from guests, but guard anyway)
+          isHost && (
+            <SourceControlPanel
+              onCommit={handleCommit}
+              onViewDiff={(filePath) => {
+                const file = files.find((f) => f.path === filePath);
+                if (file) openFileInWorkspace(file);
+                setDiffFilePath(filePath);
+                setShowDiff(true);
+              }}
+              isCommitting={isSaving}
+            />
+          )
+        )}
       </div>
 
-      <div className="flex flex-1 flex-col">
+      {/* ── Main content ─────────────────────────────────────────────────── */}
+      <div className="flex flex-1 flex-col min-w-0">
         {/* Header */}
-        <header className="flex h-16 shrink-0 items-center gap-2 border-b border-border px-4">
+        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4 bg-background">
           <div className="flex flex-1 items-center gap-4">
             <div className="flex items-center gap-3">
               <Users className="h-5 w-5 text-primary" />
@@ -289,11 +920,32 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
                 <h1 className="font-semibold">GitHub Collaboration</h1>
                 <p className="text-xs text-muted-foreground">
                   {session.repoOwner}/{session.repoName} • {session.branch}
+                  {isHost && (
+                    <span className="ml-2 px-1.5 py-0.5 bg-primary/10 text-primary rounded text-xs">
+                      Host
+                    </span>
+                  )}
                 </p>
               </div>
             </div>
 
+            {/* Active file info */}
+            {activeFile && (
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">
+                  {activeFile.path.split("/").pop()}
+                </span>
+                {activeFile.hasChanges && (
+                  <div className="flex items-center gap-1 text-xs text-orange-600">
+                    <span className="h-2 w-2 rounded-full bg-orange-500" />
+                    <span>Modified</span>
+                  </div>
+                )}
+              </div>
+            )}
+
             <div className="ml-auto flex items-center gap-4">
+              {/* Connection status */}
               <div className="flex items-center gap-2">
                 {isConnected ? (
                   <>
@@ -315,13 +967,13 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
 
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Clock className="h-4 w-4" />
-                <span className="text-sm">Expires in {hoursRemaining}h</span>
+                <span>Expires in {hoursRemaining}h</span>
               </div>
             </div>
           </div>
         </header>
 
-        {/* Participants Bar */}
+        {/* Participants bar */}
         {participants.length > 0 && (
           <div className="border-b bg-muted/10 px-4 py-2">
             <div className="flex items-center gap-2 flex-wrap">
@@ -337,7 +989,7 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
                   </span>
                   {participant.activeFile && (
                     <span className="text-xs text-muted-foreground ml-1">
-                      • {participant.activeFile.split('/').pop()}
+                      • {participant.activeFile.split("/").pop()}
                     </span>
                   )}
                 </div>
@@ -346,72 +998,86 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
           </div>
         )}
 
-        {/* File Tab (if file is open) */}
-        {openFile && (
-          <div className="border-b border-border bg-muted/30">
-            <div className="flex items-center justify-between px-4 py-2">
-              <div className="flex items-center gap-2">
-                <FileText className="h-4 w-4" />
-                <span className="text-sm font-medium">{openFile.name}</span>
-                <span className="text-xs text-muted-foreground">
-                  {openFile.path}
-                </span>
-              </div>
-              <button
-                onClick={() => setOpenFile(null)}
-                className="hover:bg-muted rounded p-1"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Main Content - Editor */}
-        <div className="flex-1 overflow-hidden">
-          {isLoadingFile ? (
-            <div className="flex items-center justify-center h-full">
-              <Loader2 className="h-8 w-8 animate-spin" />
-            </div>
-          ) : openFile ? (
-            <CollabEditor
-              sessionId={session.sessionId}
-              userId={user?.id}
-              userName={user?.name || "Anonymous"}
-              fileId={openFile.sha}
-              filePath={openFile.path}
-              initialContent={openFile.content}
-              language={getEditorLanguage(openFile.name.split('.').pop() || '')}
-              // 🔥 Read-only - no onContentChange handler
-              remoteCursors={[]}
-            />
-          ) : (
-            <div className="flex flex-col items-center justify-center h-full text-center space-y-4 p-8">
-              <GitBranch className="h-16 w-16 text-muted-foreground" />
-              <h2 className="text-2xl font-bold">GitHub Collaboration Room</h2>
-              <p className="text-muted-foreground max-w-md">
-                Repository: <span className="font-mono">{session.repoOwner}/{session.repoName}</span>
-              </p>
-              <p className="text-muted-foreground max-w-md">
-                Branch: <span className="font-mono">{session.branch}</span>
-              </p>
-              <div className="pt-4">
-                <div className="inline-flex items-center gap-2 px-4 py-2 bg-green-50 border border-green-200 rounded-lg">
-                  <div className="h-3 w-3 rounded-full bg-green-500 animate-pulse" />
-                  <span className="text-sm text-green-700 font-medium">
-                    {participants.length} {participants.length === 1 ? 'person' : 'people'} connected
-                  </span>
+        {/* Editor area */}
+        <ResizablePanelGroup direction="horizontal" className="flex-1">
+          <ResizablePanel defaultSize={showPreview ? 50 : 100} minSize={30}>
+            <div className="flex flex-col h-full">
+              {showDiff && diffFilePath ? (
+                <DiffViewer
+                  originalContent={remoteState.get(diffFilePath) ?? ""}
+                  modifiedContent={
+                    openFiles.find((f) => f.path === diffFilePath)?.content ??
+                    remoteState.get(diffFilePath) ??
+                    ""
+                  }
+                  filepath={diffFilePath}
+                  onClose={() => {
+                    setShowDiff(false);
+                    setDiffFilePath(null);
+                  }}
+                />
+              ) : activeFile ? (
+                <PlaygroundEditor
+                  activeFile={{
+                    filename:
+                      activeFile.path.split("/").pop()?.split(".")[0] || "file",
+                    fileExtension:
+                      activeFile.path.split(".").pop() || "txt",
+                    content: activeFile.content,
+                  }}
+                  content={activeFile.content}
+                  onContentChange={handleContentChange}
+                  suggestionLoading={false}
+                  suggestions={null}
+                  suggestionPosition={null}
+                  onAcceptSuggestion={() => {}}
+                  onRejectSuggestion={() => {}}
+                  onTriggerSuggestion={() => {}}
+                  disableAI={true}
+                />
+              ) : (
+                <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+                  <GitBranch className="h-16 w-16 mb-4" />
+                  <p className="text-lg">Select a file to start editing</p>
+                  <p className="text-sm mt-2">
+                    Editing on branch:{" "}
+                    <span className="font-mono">{session.branch}</span>
+                  </p>
+                  <div className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-green-50 border border-green-200 rounded-lg">
+                    <div className="h-3 w-3 rounded-full bg-green-500 animate-pulse" />
+                    <span className="text-sm text-green-700 font-medium">
+                      {participants.length}{" "}
+                      {participants.length === 1 ? "person" : "people"} connected
+                    </span>
+                  </div>
                 </div>
-              </div>
-              <p className="text-sm text-muted-foreground pt-4">
-                Select a file from the sidebar to view code
-              </p>
+              )}
             </div>
+          </ResizablePanel>
+
+          {isWebContainerSupported && (
+            <>
+              <ResizableHandle />
+              <ResizablePanel defaultSize={50} minSize={30}>
+                <WebContainerPreview
+                  serverUrl={serverUrl}
+                  isLoading={isWebContainerLoading}
+                  error={webContainerError}
+                  instance={webContainerInstance}
+                  onRestartServer={restartServer}
+                  terminalRef={terminalRef}
+                  showTerminal={true}
+                  onServerReady={(url) => {
+                    console.log("📡 Server ready:", url);
+                  }}
+                />
+              </ResizablePanel>
+            </>
           )}
-        </div>
+        </ResizablePanelGroup>
       </div>
 
-      {/* Participants & Activity Panel */}
+      {/* Participants & Activity Panel (reused from original) */}
       <ParticipantsPanel
         participants={participants}
         activityLogs={activityLogs}
@@ -419,6 +1085,71 @@ export function GitHubCollabPlayground({ session }: GitHubCollabPlaygroundProps)
         followingUserId={null}
         onFollowToggle={() => {}}
       />
+
+      {/* ── Dialogs ──────────────────────────────────────────────────────── */}
+      <NewFileDialog
+        open={newFileDialogOpen}
+        onOpenChange={setNewFileDialogOpen}
+        onCreateFile={handleCreateFile}
+        currentPath={currentContextPath}
+      />
+
+      <NewFolderDialog
+        open={newFolderDialogOpen}
+        onOpenChange={setNewFolderDialogOpen}
+        onCreateFolder={handleCreateFolder}
+        currentPath={currentContextPath}
+      />
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete File</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete{" "}
+              <strong>{fileToDelete?.name}</strong>?
+              {fileToDelete?.sha
+                ? " This will stage the deletion — commit via Source Control to apply to GitHub."
+                : " This file only exists locally and will be permanently removed."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteFile}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={deleteFolderDialogOpen}
+        onOpenChange={setDeleteFolderDialogOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Folder</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete{" "}
+              <strong>{folderToDelete?.name}</strong> and all its contents?
+              Files on GitHub will be staged for deletion and must be committed
+              via Source Control.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteFolder}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete Folder
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 

--- a/modules/collaboration/hooks/useCollabWorkspace.ts
+++ b/modules/collaboration/hooks/useCollabWorkspace.ts
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useRef } from "react";
+import { Socket } from "socket.io-client";
+import { useGitWorkspace } from "@/modules/github/hooks/Usegitworkspace";
+
+export interface EditorChangePayload {
+  sessionId: string;
+  userId?: string;
+  userName?: string;
+  fileId: string;   // sha — used as stable file identifier
+  filePath: string;
+  content: string;
+  changes: any;
+  timestamp: number;
+}
+
+export interface FileActionPayload {
+  sessionId: string;
+  userId?: string;
+  userName?: string;
+  /** "create" | "delete" | "rename" */
+  action: "create" | "delete" | "rename";
+  filePath: string;
+  newPath?: string;   // only for rename
+  content?: string;   // only for create
+}
+
+interface GitHubFile {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  type: "file" | "dir";
+  content?: string;
+}
+
+interface UseCollabWorkspaceProps {
+  socket: Socket | null;
+  sessionId: string;
+  currentUserId?: string;
+  /** WebContainer instance — passed through but not used in Phase 1 */
+  webContainerInstance?: any | null;
+}
+
+export function useCollabWorkspace({
+  socket,
+  sessionId,
+  currentUserId,
+  webContainerInstance,
+}: UseCollabWorkspaceProps){
+    const updateFileContent  = useGitWorkspace((s) => s.updateFileContent);
+  const addFileToTree      = useGitWorkspace((s) => s.addFileToTree);
+  const markFileCreated    = useGitWorkspace((s) => s.markFileCreated);
+  const removeFileFromTree = useGitWorkspace((s) => s.removeFileFromTree);
+  const markFileDeleted    = useGitWorkspace((s) => s.markFileDeleted);
+  const unmarkFileCreated  = useGitWorkspace((s) => s.unmarkFileCreated);
+  const openFileInWorkspace = useGitWorkspace((s) => s.openFile);
+  const openFiles          = useGitWorkspace((s) => s.openFiles);
+  const files              = useGitWorkspace((s) => s.files);
+  const openFilesRef = useRef(openFiles);
+  const filesRef     = useRef(files);
+  useEffect(() => { openFilesRef.current = openFiles; }, [openFiles]);
+  useEffect(() => { filesRef.current = files; }, [files]);
+
+  const handleRemoteEditorChange = useCallback(
+    (payload: EditorChangePayload) => {
+      // Ignore own echoes
+      if (payload.userId === currentUserId) return;
+
+      console.log(
+        `[CollabWorkspace] ✏️ Remote edit on ${payload.filePath} from ${payload.userName}`
+      );
+      const isAlreadyOpen = openFilesRef.current.some(
+        (f) => f.path === payload.filePath
+      );
+
+      if (!isAlreadyOpen) {
+        // File exists in the tree but hasn't been opened as a tab yet.
+        // We must add it to openFiles before updateFileContent can touch it.
+        const treeFile = filesRef.current.find(
+          (f) => f.path === payload.filePath
+        );
+        if (treeFile) {
+          // openFile seeds openFiles with the original remote content,
+          // then updateFileContent below overwrites it with the new content.
+          openFileInWorkspace(treeFile);
+        }
+      }
+
+      // updateFileContent drives both the open-file tab content and the
+      // modifiedFiles set — same path as the single-user playground.
+      updateFileContent(payload.filePath, payload.content);
+    },
+    [currentUserId, updateFileContent, openFileInWorkspace]
+  );
+    const handleRemoteFileAction = useCallback(
+    (payload: FileActionPayload) => {
+      if (payload.userId === currentUserId) return;
+
+      console.log(
+        `[CollabWorkspace] 📁 Remote file:action "${payload.action}" on ${payload.filePath} from ${payload.userName}`
+      );
+
+      switch (payload.action) {
+        // ── CREATE ────────────────────────────────────────────────────────
+        case "create": {
+          const alreadyExists = filesRef.current.some(
+            (f) => f.path === payload.filePath
+          );
+          if (alreadyExists) {
+            console.warn(
+              `[CollabWorkspace] ⚠️ File already exists locally, skipping create: ${payload.filePath}`
+            );
+            return;
+          }
+
+          const newFile: GitHubFile = {
+            name: payload.filePath.split("/").pop() || payload.filePath,
+            path: payload.filePath,
+            sha: "",        // not on GitHub yet
+            size: (payload.content ?? "").length,
+            type: "file",
+            content: payload.content ?? "",
+          };
+
+          addFileToTree(newFile);
+          // Pass content so the draft is correct if the file is opened
+          markFileCreated(payload.filePath, payload.content ?? "");
+          break;
+        }
+
+        // ── DELETE ────────────────────────────────────────────────────────
+        case "delete": {
+          const target = filesRef.current.find(
+            (f) => f.path === payload.filePath
+          );
+
+          removeFileFromTree(payload.filePath);
+
+          if (!target?.sha) {
+            // Local-only file — just untrack
+            unmarkFileCreated(payload.filePath);
+          } else {
+            // GitHub file — stage for deletion
+            markFileDeleted(payload.filePath);
+          }
+          break;
+        }
+
+        // ── RENAME ────────────────────────────────────────────────────────
+        case "rename": {
+          if (!payload.newPath) {
+            console.warn("[CollabWorkspace] ⚠️ rename action missing newPath");
+            return;
+          }
+
+          const oldFile = filesRef.current.find(
+            (f) => f.path === payload.filePath
+          );
+
+          // --- Delete-side ---
+          removeFileFromTree(payload.filePath);
+          if (!oldFile?.sha) {
+            unmarkFileCreated(payload.filePath);
+          } else {
+            markFileDeleted(payload.filePath);
+          }
+
+          // --- Add-side ---
+          const currentContent =
+            openFilesRef.current.find((f) => f.path === payload.filePath)
+              ?.content ??
+            oldFile?.content ??
+            payload.content ??
+            "";
+
+          const renamedFile: GitHubFile = {
+            name: payload.newPath.split("/").pop() || payload.newPath,
+            path: payload.newPath,
+            sha: "",
+            size: currentContent.length,
+            type: "file",
+            content: currentContent,
+          };
+
+          addFileToTree(renamedFile);
+          markFileCreated(payload.newPath, currentContent);
+          break;
+        }
+
+        default:
+          console.warn(
+            `[CollabWorkspace] ⚠️ Unknown file:action: ${(payload as any).action}`
+          );
+      }
+    },
+    [
+      currentUserId,
+      addFileToTree,
+      markFileCreated,
+      removeFileFromTree,
+      markFileDeleted,
+      unmarkFileCreated,
+    ]
+  );
+
+
+  useEffect(() => {
+    if (!socket) return;
+
+    console.log("[CollabWorkspace] 🔌 Attaching workspace socket listeners");
+
+    socket.on("editor:change", handleRemoteEditorChange);
+    socket.on("file:action",   handleRemoteFileAction);
+
+    return () => {
+      socket.off("editor:change", handleRemoteEditorChange);
+      socket.off("file:action",   handleRemoteFileAction);
+      console.log("[CollabWorkspace] 🧹 Removed workspace socket listeners");
+    };
+  }, [socket, handleRemoteEditorChange, handleRemoteFileAction]);
+
+  const broadcastContentChange = useCallback(
+    (filePath: string, sha: string, content: string) => {
+      if (!socket?.connected) return;
+
+      const payload: EditorChangePayload = {
+        sessionId,
+        userId:    currentUserId,
+        fileId:    sha || filePath,   // fall back to path when sha is empty
+        filePath,
+        content,
+        changes:   [],                // Phase 1: full-content sync, no deltas
+        timestamp: Date.now(),
+      };
+
+      socket.emit("editor:change", payload);
+    },
+    [socket, sessionId, currentUserId]
+  );
+  const broadcastFileCreate = useCallback(
+    (filePath: string, content: string) => {
+      if (!socket?.connected) return;
+
+      const payload: FileActionPayload = {
+        sessionId,
+        userId:   currentUserId,
+        action:   "create",
+        filePath,
+        content,
+      };
+
+      socket.emit("file:action", payload);
+    },
+    [socket, sessionId, currentUserId]
+  );
+
+  /**
+   * Emit a file:action "delete" event to peers.
+   */
+  const broadcastFileDelete = useCallback(
+    (filePath: string) => {
+      if (!socket?.connected) return;
+
+      const payload: FileActionPayload = {
+        sessionId,
+        userId:   currentUserId,
+        action:   "delete",
+        filePath,
+      };
+
+      socket.emit("file:action", payload);
+    },
+    [socket, sessionId, currentUserId]
+  );
+
+  /**
+   * Emit a file:action "rename" event to peers.
+   */
+  const broadcastFileRename = useCallback(
+    (oldPath: string, newPath: string, content: string) => {
+      if (!socket?.connected) return;
+
+      const payload: FileActionPayload = {
+        sessionId,
+        userId:   currentUserId,
+        action:   "rename",
+        filePath: oldPath,
+        newPath,
+        content,
+      };
+
+      socket.emit("file:action", payload);
+    },
+    [socket, sessionId, currentUserId]
+  );
+
+  return {
+    broadcastContentChange,
+    broadcastFileCreate,
+    broadcastFileDelete,
+    broadcastFileRename,
+  };
+
+
+}

--- a/modules/github/components/github-file-tree.tsx
+++ b/modules/github/components/github-file-tree.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { ChevronRight, ChevronDown, File, Folder, Plus, FilePlus, FolderPlus, MoreHorizontal, Trash2 } from "lucide-react"
+import { ChevronRight, ChevronDown, File, Folder, Plus, FilePlus, FolderPlus, MoreHorizontal, Trash2 ,Pencil} from "lucide-react"
 import { cn } from "@/lib/utils"
 import {
   DropdownMenu,
@@ -27,6 +27,8 @@ interface FileTreeProps {
   onCreateFolder?: (path: string) => void
   onDeleteFile?: (file: GitHubFile) => void
   onDeleteFolder?: (folderPath: string, folderName: string) => void 
+  onRenameFile?: (file: GitHubFile, newName: string) => void
+  onRenameFolder?: (folderPath: string, folderName: string, newName: string) => void
   expandedDirs?: Set<string> 
   onExpandedDirsChange?: (dirs: Set<string>) => void 
   modifiedFiles?: Set<string>
@@ -47,8 +49,12 @@ export function GitHubFileTree({
   modifiedFiles,
   createdFiles,
   deletedFiles,
+  onRenameFile,
+  onRenameFolder,
 }: FileTreeProps) {
   const [internalExpandedDirs, setInternalExpandedDirs] = useState<Set<string>>(new Set([""]))
+  const [renamingPath, setRenamingPath] = useState<string | null>(null)
+const [renameValue, setRenameValue] = useState("")
 
   
   const expandedDirs = controlledExpandedDirs ?? internalExpandedDirs
@@ -180,15 +186,46 @@ export function GitHubFileTree({
               onClick={() => onFileSelect(file)}
             >
               <File className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="truncate">{file.name}</span>
-              {modifiedFiles?.has(file.path) && (
-        <span className="ml-auto text-xs text-orange-500">M</span>
-      )}
-      {createdFiles?.has(file.path) && (
-        <span className="ml-auto text-xs text-green-500">A</span>
-      )}
-      {deletedFiles?.has(file.path) && (
-        <span className="ml-auto text-xs text-red-500">D</span>
+               {renamingPath === file.path ? (
+        <input
+          autoFocus
+          className="flex-1 bg-background border border-primary rounded px-1 text-sm outline-none"
+          value={renameValue}
+          onChange={e => setRenameValue(e.target.value)}
+          onBlur={() => {
+            const trimmed = renameValue.trim()
+            if (trimmed && trimmed !== file.name) {
+              onRenameFile?.(file, trimmed)
+            }
+            setRenamingPath(null)
+          }}
+          onKeyDown={e => {
+            if (e.key === "Enter") {
+              const trimmed = renameValue.trim()
+              if (trimmed && trimmed !== file.name) {
+                onRenameFile?.(file, trimmed)
+              }
+              setRenamingPath(null)
+            }
+            if (e.key === "Escape") {
+              setRenamingPath(null)
+            }
+          }}
+          onClick={e => e.stopPropagation()}
+        />
+      ) : (
+        <>
+          <span className="truncate">{file.name}</span>
+          {modifiedFiles?.has(file.path) && (
+            <span className="ml-auto text-xs text-orange-500">M</span>
+          )}
+          {createdFiles?.has(file.path) && (
+            <span className="ml-auto text-xs text-green-500">A</span>
+          )}
+          {deletedFiles?.has(file.path) && (
+            <span className="ml-auto text-xs text-red-500">D</span>
+          )}
+        </>
       )}
             </div>
 
@@ -204,14 +241,26 @@ export function GitHubFileTree({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem 
-                    onClick={() => onDeleteFile(file)}
-                    className="text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4 mr-2" />
-                    Delete
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
+  {onRenameFile && (
+    <DropdownMenuItem
+      onClick={() => {
+        setRenameValue(file.name)
+        setRenamingPath(file.path)
+      }}
+    >
+      <Pencil className="h-4 w-4 mr-2" />
+      Rename
+    </DropdownMenuItem>
+  )}
+  {onRenameFile && <DropdownMenuSeparator />}
+  <DropdownMenuItem
+    onClick={() => onDeleteFile(file)}
+    className="text-destructive"
+  >
+    <Trash2 className="h-4 w-4 mr-2" />
+    Delete
+  </DropdownMenuItem>
+</DropdownMenuContent>
               </DropdownMenu>
             )}
           </div>

--- a/modules/github/components/github-playground.tsx
+++ b/modules/github/components/github-playground.tsx
@@ -1,5 +1,5 @@
 "use client"
-
+//github single user playground
 import { useState, useEffect, useCallback, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { 
@@ -594,6 +594,75 @@ const remoteState = useGitWorkspace(state => state.remoteState)
   setFolderToDelete(null)
 
   }
+
+  async function handleRenameFile(file: GitHubFile, newName: string) {
+  // Build the new path — same directory, new filename
+  const dir = file.path.includes("/")
+    ? file.path.substring(0, file.path.lastIndexOf("/"))
+    : ""
+  const newPath = dir ? `${dir}/${newName}` : newName
+
+  // Guard: new path already exists
+  if (files.some(f => f.path === newPath)) {
+    toast.error(`"${newName}" already exists`)
+    return
+  }
+
+  // ── Step 1: Handle old path (delete side) ──
+  if (activeFile?.path === file.path) {
+    closeFile(file.path)
+  }
+
+  removeFileFromTree(file.path)
+
+  if (!file.sha) {
+    // Local-only file — just untrack
+    unmarkFileCreated(file.path)
+  } else {
+    // GitHub file — stage for deletion
+    markFileDeleted(file.path)
+  }
+
+  // ── Step 2: Handle new path (add side) ──
+  // Carry over the content from the old file
+  const currentContent =
+    openFiles.find(f => f.path === file.path)?.content ??
+    file.content ??
+    ""
+
+  const newFile: GitHubFile = {
+    name: newName,
+    path: newPath,
+    sha: "",           // not on GitHub yet
+    size: currentContent.length,
+    type: "file",
+    content: currentContent,
+  }
+
+  addFileToTree(newFile)
+  markFileCreated(newPath)
+
+  // Open the renamed file so user doesn't lose their place
+  openFileInWorkspace(newFile)
+
+  // Mirror in WebContainer if running
+  if (webContainerInstance && isReady) {
+    try {
+      // Write new path
+      const dir = newPath.split("/").slice(0, -1).join("/")
+      if (dir) await webContainerInstance.fs.mkdir(`/${dir}`, { recursive: true })
+      await webContainerInstance.fs.writeFile(`/${newPath}`, currentContent, "utf-8")
+      // Remove old path
+      await webContainerInstance.fs.rm(`/${file.path}`)
+    } catch (e) {
+      console.warn("WC rename sync failed:", e)
+    }
+  }
+
+  toast.success(`Renamed to ${newName}`, {
+    description: "Staged as D + A. Commit via Source Control.",
+  })
+}
   useEffect(() => {
   if (!isReady || !webContainerInstance) return
   if(draftRestoredAt === 0) return;
@@ -802,44 +871,57 @@ const handleFileCreated = async (filePath: string, parentPath: string) => {
     }
     
     const handleFileRenamed = async (oldPath: string, newPath: string, parentPath: string) => {
-      if (manuallyCreatedFilesRef.current.has(newPath)) return
-      
-      console.log(`✏️ [GITHUB] File renamed: ${oldPath} → ${newPath}`)
-      
-      try {
-        const oldFile = files.find(f => f.path === oldPath)
-        if (!oldFile) {
-          console.warn(`File not found: ${oldPath}`)
-          return
-        }
-        
-        const content = await webContainerInstance.fs.readFile(`/${newPath}`, 'utf-8')
-        
-        const newFile: GitHubFile = {
-          ...oldFile,
-          name: newPath.split('/').pop() || '',
-          path: newPath,
-          sha: '',
-          content,
-        }
-        
-        removeFileFromTree(oldPath)
-        addFileToTree(newFile)
-        
-        if (activeFile?.path === oldPath) {
-          closeFile(oldPath)
-          openFileInWorkspace(newFile)
-        }
-        
-        manuallyCreatedFilesRef.current.add(newPath)
-        setTimeout(() => manuallyCreatedFilesRef.current.delete(newPath), 3000)
-        
-        toast.info(`✏️ Renamed ${oldPath.split('/').pop()} → ${newPath.split('/').pop()} (not committed)`, {
-          description: 'Commit when ready'
-        })
-      } catch (error) {
-        console.error(`❌ Failed to rename file:`, error)
+       if (manuallyCreatedFilesRef.current.has(newPath)) return
+  if (useGitWorkspace.getState().isSwitchingBranch) return
+
+  console.log(`✏️ [GITHUB] File renamed (treated as D+A): ${oldPath} → ${newPath}`)
+
+  try {
+    // --- 1. Handle the OLD path (delete) ---
+    const oldFile = files.find(f => f.path === oldPath)
+
+    if (oldFile) {
+      removeFileFromTree(oldPath)
+
+      if (!oldFile.sha) {
+        // Local-only file: just untrack it, nothing to stage
+        unmarkFileCreated(oldPath)
+      } else {
+        // GitHub file: stage for deletion
+        markFileDeleted(oldPath)
       }
+
+      if (activeFile?.path === oldPath) {
+        closeFile(oldPath)
+      }
+    }
+
+    // --- 2. Handle the NEW path (add) ---
+    const content = await webContainerInstance.fs.readFile(`/${newPath}`, 'utf-8')
+
+    const newFile: GitHubFile = {
+      name: newPath.split('/').pop() || '',
+      path: newPath,
+      sha: '',           // brand new — not on GitHub yet
+      size: content.length,
+      type: 'file',
+      content,
+    }
+
+    addFileToTree(newFile)
+    markFileCreated(newPath)
+
+    if (parentPath) {
+      setExpandedDirs(prev => new Set([...prev, parentPath]))
+    }
+
+    toast.info(
+      `${oldPath.split('/').pop()} → ${newPath.split('/').pop()}`,
+      { description: 'Staged as D + A. Commit via Source Control.' }
+    )
+  } catch (error) {
+    console.error(`❌ Failed to handle rename:`, error)
+  }
     }
     
     fileCreationWatcher.initialize(
@@ -1002,6 +1084,7 @@ const handleFileCreated = async (filePath: string, parentPath: string) => {
               modifiedFiles={modifiedFiles}
               createdFiles={createdFiles}
               deletedFiles={deletedFiles}
+              onRenameFile={handleRenameFile}
             />
           )}
         </div>


### PR DESCRIPTION
- Implemented renaming for files and folders in the GitHub file tree component.
- Added input field for renaming files with appropriate event handling.
- Integrated renaming logic in the playground to handle file path updates.
- Created a new hook for collaboration workspace to manage remote file actions including renaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time collaborative editing with host and guest permission levels
  * Enhanced file management: create, delete, and rename files in the repository
  * Side-by-side diff viewer to track file changes
  * Integrated terminal for running commands
  * Live preview with web container server controls (start, stop, restart)
  * Source control panel for committing changes
  * Connection status and active participant indicators
  * Resizable editor and preview panels for flexible workspace layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->